### PR TITLE
init-scripts: Update logging for gcsfuse initialization and mounting

### DIFF
--- a/scripts/create_pcap_dir
+++ b/scripts/create_pcap_dir
@@ -4,8 +4,10 @@ set +x
 
 while : ; do
     gcsfuse_ready=$(mount | grep --color=never "${PCAP_MNT} type fuse" | wc -l | tr -d '\n')
-    [[ "${gcsfuse_ready}" == '1' ]] && break
-    echo "{\"severity\":\"WARNING\",\"message\":\"GCS Bucket ${PCAP_GCS_BUCKET} not mounted at ${PCAP_MNT}\",\"sidecar\":\"${APP_SIDECAR}\",\"module\":\"${PROC_NAME}\"}"
+    [[ "${gcsfuse_ready}" == '1' ]] \
+        && echo "{\"severity\":\"INFO\",\"message\":\"GCS Bucket ${PCAP_GCS_BUCKET} is now mounted at ${PCAP_MNT}\",\"sidecar\":\"${APP_SIDECAR}\",\"module\":\"${PROC_NAME}\"}" \
+        && break
+    echo "{\"severity\":\"WARNING\",\"message\":\"Waiting for GCS Bucket ${PCAP_GCS_BUCKET} to be mounted at ${PCAP_MNT} ...\",\"sidecar\":\"${APP_SIDECAR}\",\"module\":\"${PROC_NAME}\"}"
     sleep 1
 done
 
@@ -13,4 +15,4 @@ mount | grep --color=never "${PCAP_MNT} type fuse"
 
 set -x
 
-mkdir -p "${PCAP_DIR}"
+mkdir -pv "${PCAP_DIR}"

--- a/scripts/init
+++ b/scripts/init
@@ -117,10 +117,10 @@ echo "PCAP_TCP_FLAGS=${PCAP_TCP_FLAGS:-ALL}" >> ${ENV_FILE}
 echo "PCAP_RT_ENV=@PCAP_RT_ENV@" >> ${ENV_FILE}
 
 # Create both paths to store PCAP files
-mkdir -p ${PCAP_MNT}
-mkdir -p ${PCAP_TMP}
+mkdir -pv ${PCAP_MNT}
+mkdir -pv ${PCAP_TMP}
 
-echo "[INFO] - PCAP files available at: gs://${PCAP_GCS_BUCKET}/${GCS_DIR}"
+echo "[INFO] - PCAP files will be available at: gs://${PCAP_GCS_BUCKET}/${GCS_DIR}"
 
 trap 'kill -TERM $PCAP_PID' TERM INT
 /bin/supervisord --configuration=/tcpdump.conf --env-file=${ENV_FILE} &

--- a/scripts/start_pcapfsn
+++ b/scripts/start_pcapfsn
@@ -3,8 +3,10 @@
 set +x
 
 while : ; do
-    [[ -d ${PCAP_DIR} ]] && break
-    echo "{\"severity\":\"WARNING\",\"message\":\"PCAP files directory is not available: ${PCAP_DIR}\",\"sidecar\":\"${APP_SIDECAR}\",\"module\":\"${PROC_NAME}\"}"
+    [[ -d ${PCAP_DIR} ]] \
+        && echo "{\"severity\":\"INFO\",\"message\":\"PCAP files directory is now available at: ${PCAP_DIR}\",\"sidecar\":\"${APP_SIDECAR}\",\"module\":\"${PROC_NAME}\"}" \
+        && break
+    echo "{\"severity\":\"WARNING\",\"message\":\"Waiting for PCAP files directory to be available at: ${PCAP_DIR} ...\",\"sidecar\":\"${APP_SIDECAR}\",\"module\":\"${PROC_NAME}\"}"
     sleep 1
 done
 

--- a/scripts/start_tcpdumpw
+++ b/scripts/start_tcpdumpw
@@ -4,8 +4,10 @@ set +x
 
 while : ; do
     pcapfsn_ready=$(ps -efa | grep --color=never '/pcap_fsn' | grep --color=never -v grep | wc -l  | tr -d '\n')
-    [[ "${pcapfsn_ready}" == '1' ]] && break
-    echo "{\"severity\":\"WARNING\",\"message\":\"PCAP FS notifier is not running\",\"sidecar\":\"${APP_SIDECAR}\",\"module\":\"${PROC_NAME}\"}"
+    [[ "${pcapfsn_ready}" == '1' ]] \
+        && echo "{\"severity\":\"INFO\",\"message\":\"PCAP FS notifier is running\",\"sidecar\":\"${APP_SIDECAR}\",\"module\":\"${PROC_NAME}\"}" \
+        && break
+    echo "{\"severity\":\"WARNING\",\"message\":\"Waiting for PCAP FS notifier to run ...\",\"sidecar\":\"${APP_SIDECAR}\",\"module\":\"${PROC_NAME}\"}"
     sleep 1
 done
 


### PR DESCRIPTION
Improve WARNING logs to clearly indicate retry attempts and successful completion of the infinite loops.
This provides better visibility into the potentially longer-running initialization phase.
Log an INFO severity message upon success, before exiting the retry loop.